### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,5 +1,7 @@
 on: push
 name: 🚀 Deploy website on push
+permissions:
+  contents: read
 jobs:
   web-deploy:
     name: 🎉 Deploy


### PR DESCRIPTION
Potential fix for [https://github.com/Devstao/website/security/code-scanning/2](https://github.com/Devstao/website/security/code-scanning/2)

To fix the problem, explicitly specify the `permissions` key either at the root of the workflow or within the job to ensure the GITHUB_TOKEN is limited to only those permissions necessary for the workflow to function. In this case, since the jobs only check out code and do an FTP deploy (neither of which requires a GitHub token with write permissions), using `permissions: contents: read` is appropriate and follows the principle of least privilege. The fix involves adding a `permissions` block, either at the top after the `name:` key (to be inherited by all jobs), or at the job level under `web-deploy:`. The root-level approach is simplest and ensures all present and future jobs use least-privilege permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
